### PR TITLE
Fix twitter query formatting

### DIFF
--- a/src/controllers/register.ts
+++ b/src/controllers/register.ts
@@ -85,7 +85,7 @@ const register = async (req: Request, res: Response) => {
 		const projectConfig = projectConfigResponse[0];
 		const { pre_defined_tweet_text } = projectConfig;
 
-		const tweetsResponse = await client.v2.search({	query: `from:${user.id} ${pre_defined_tweet_text}` });
+		const tweetsResponse = await client.v2.search({	query: `from:${user.data.id} "${pre_defined_tweet_text}"` });
 		const tweets = tweetsResponse.tweets;
 		if (!tweets || tweets.length === 0) {
 			return res.status(StatusCodes.FORBIDDEN).send({


### PR DESCRIPTION
- grab correct id
- wrap the search term in quotes

Testing:
e2e tested locally via API calls
- user that has not tweeted required text registration fails
- user that has tweeted required text registration succeeds